### PR TITLE
Add deployment guide for GCP CVM

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ In above diagram:
 
 - **CCNP** is used to calculate the measurement for node, namespace,
 POD and cluster level.
-- **CC Trusted API** provided unified API to tenant to access measurement, event log
+- **CC Trusted API** provides unified API to tenant to access measurement, event log
 and quote (report).
 
 ## 2. Confidential Cluster
@@ -34,4 +34,14 @@ and quote (report).
 | Attestation | [Google Managed vTPM](https://cloud.google.com/confidential-computing/confidential-vm/docs/attestation) | [Microsoft Azure Attestation](https://azure.microsoft.com/en-us/products/azure-attestation/)/[Intel® Trust Authority](https://www.intel.com/content/www/us/en/security/trust-authority.html) |
 | Tutorial | [Here](https://cloud.google.com/kubernetes-engine/docs/how-to/confidential-gke-nodes#enabling_in_a_new_cluster) | [here](https://learn.microsoft.com/en-us/azure/confidential-computing/confidential-vm-overview)
 
-## 3. Deploy
+## 3. Deployment
+
+There are 2 options creating a confidential cluster.
+
+- Create a few confidential VMs (CVMs) and deploy Kubernetes within them. The CVMs can be on local hosts if you have supported hardware. The CVMs can also be applied from CSP.
+The document [single_node_gcp.md](./deployment/single_node_gcp.md) shows how to apply for a TD on Google Cloud TDX Preview and start a Kubernetes cluster in the single
+confidential node.
+- Create [Confidential GKE node](https://cloud.google.com/blog/products/identity-security/announcing-general-availability-of-confidential-gke-nodes) on Google cloud.
+
+
+Find details in [deployment guide](./deployment/).

--- a/deployment/gcp_td.sh
+++ b/deployment/gcp_td.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+PROJECT_ID=""
+VM_NAME="vm_test"
+EXTERNAL_IP=""
+PUB_KEY=""
+
+
+function usage {
+    cat << EOM
+usage: $(basename "$0") [OPTION]...
+    -i <project id> the GCP project id
+    -n <vm name> the VM name
+    -e <external IP> external IP of the VM
+    -k <public key> ssh public key
+EOM
+    exit 1
+}
+
+function process_args {
+while getopts ":i:n:e:k:" option; do
+        case "${option}" in
+            i) PROJECT_ID=${OPTARG};;
+            n) VM_NAME=${OPTARG};;
+            e) EXTERNAL_IP=${OPTARG};;
+            k) PUB_KEY=${OPTARG};;
+            h) usage;;
+            *) echo "Invalid option: -${OPTARG}" >&2
+               usage
+               ;;
+        esac
+    done
+
+    if [[ -z "$EXTERNAL_IP" ]]; then
+        echo "Warning: Please set external IP or you won't be able to ssh the VM."
+            exit 1
+    fi
+
+    if [[ -z "$PROJECT_ID" ]]; then
+        echo "ERROR: Please pass project ID."
+            exit 1
+    fi
+
+    if [[ -z "$PUB_KEY" ]]; then
+        echo "ERROR: Please pass public key."
+            exit 1
+    fi
+}
+process_args "$@"
+
+curl -X POST \
+     -H "Authorization: Bearer $(gcloud auth print-access-token)" \
+     -H "Content-Type: application/json" \
+     -d '{
+            "machineType": "zones/us-central1-a/machineTypes/c3-standard-4",
+            "metadata": {
+                "items": [
+                    {
+                        "key": "ssh-keys",
+                        "value": "$PUB_KEY"
+                    }
+                ]
+            },
+           "name": "'$VM_NAME'",
+           "confidentialInstanceConfig": {
+                "confidentialInstanceType": "TDX"
+            },
+            "disks": [
+                {
+                    "boot": true,
+                    "initializeParams": {
+                        "diskSizeGb": "100",
+                        "sourceImage": "projects/tdx-guest-images/global/images/ubuntu-2204-jammy-v20240501"
+                    }
+                }
+           ],
+            "networkInterfaces": [
+                {
+                    "accessConfigs": [
+                        {
+                            "name": "External NAT",
+                            "natIP": "'$EXTERNAL_IP'",
+                        }
+                    ],
+                    "stackType": "IPV4_ONLY",
+                    "subnetwork": "projects/'$PROJECT_ID'/regions/us-central1/subnetworks/default"
+                }
+           ],
+           "scheduling": {
+                "automaticRestart": true,
+                "nodeAffinities": [],
+                "onHostMaintenance": "TERMINATE",
+                "preemptible": false
+            }
+        }' \
+    https://compute.googleapis.com/compute/beta/projects/$PROJECT_ID/zones/us-central1-a/instances
+

--- a/deployment/single_node_gcp.md
+++ b/deployment/single_node_gcp.md
@@ -1,0 +1,90 @@
+# Deployment Guide on GCP CVM
+
+This guide introduces how to create a Intel TDX confidential VM (TD) on [Google cloud](https://cloud.google.com/?hl=en). Furthermore, it demonstrates how to create a Kubernetes cluster on the single CVM.
+
+## Prerequisite
+
+1. Make sure you have account on Google cloud. 
+2. Follow steps of [Before you begin](https://cloud.google.com/confidential-computing/confidential-vm/docs/create-a-confidential-vm-instance#before_you_begin) to prepare Google Cloud project, enable billing and install `gcloud CLI`.
+
+__NOTE: When running `gcloud init` to set default region and zone. Set default region to `us-central1`, set default zone to `us-central1-a`, or `us-central1-b`, or `us-central1-c` as they are [supported zone](https://cloud.google.com/confidential-computing/confidential-vm/docs/supported-configurations#supported-zones) for TDX.__
+
+## Create Google Cloud CVM
+
+Google Cloud doesn't support to create TD via UI console right now. Below steps will help you create TD instances via REST API. Find more details in the [document](https://cloud.google.com/confidential-computing/confidential-vm/docs/create-a-confidential-vm-instance#create-instance).
+
+__NOTE: The following steps need to be performed in a session in which `gcloud init` has been executed successfully.__
+
+1. Create ssh key pair. The public key will be used as metadata of the TD so that you can ssh the TD using private key.
+  
+  ```
+   $ ssh-keygen
+  ```
+
+2. Reserve an external IP for the TD. Otherwise you cannot ssh it. You can find your `ProjectID` in the page of Google Cloud [console](https://console.cloud.google.com/).
+
+  ```
+  $ gcloud compute addresses create <IP NAME> --project=<YOUR PROJECT ID> --region=us-central1
+  ```
+
+3. Use [gcp_td.sh](./gcp_td.sh) to create a TD.
+
+  ```
+  $ ./gcp_td.sh -i <projectID> -n <vm name> -e <external IP from last step> -k <content of public key>
+  ```
+__NOTE: The script uses image ubuntu-2204-jammy-v20240501. Find all TDX supported operating system image in the [document](https://cloud.google.com/confidential-computing/confidential-vm/docs/supported-configurations#operating-systems)__.
+
+Below is an example response for a successful request. 
+
+```
+{
+  "kind": "compute#operation",
+  "id": "3130168573538985222",
+  "name": "operation-1716279222227-618f272c98ade-029effcf-8c222ee8",
+  "zone": "https://www.googleapis.com/compute/beta/projects/ccnp-412909/zones/us-central1-a",
+  "operationType": "insert",
+  "targetLink": "https://www.googleapis.com/compute/beta/projects/projectid/zones/us-central1-a/instances/temp",
+  "targetId": "8235031474519272227",
+  "status": "RUNNING",
+  "user": "user@intel.com",
+  "progress": 0,
+  "insertTime": "2024-05-21T01:17:28.757-07:00",
+  "startTime": "2024-05-21T01:17:28.758-07:00",
+  "selfLink": "https://www.googleapis.com/compute/beta/projects/projectid/zones/us-central1-a/operations/operation-1716279447227-618f272c98ade-029effcf-8c440ee8"
+}
+
+```
+
+After that, you can view the TD in Google Cloud Console - Compute Engine - Virtual machines - VM instances.
+
+4. Connect to the TD. If you are behind a proxy, put below content in your config file before ssh TD.
+
+```
+$ vi ~/.ssh/config
+Host cvm
+    HostName <Replace with external IP of the TD>
+    Port 22
+    PreferredAuthentications publickey
+    IdentityFile <Replace with path of ssh private key>
+    ProxyCommand connect-proxy -S <Replace with your proxy>:1080 %h %p
+
+$ ssh cvm
+```
+
+## Install Kubernetes
+
+It's recommended to use [k3s](https://docs.k3s.io/) to start a lightweight Kubernetes cluster for experimental purpose. Or you can refer to the [Kubernetes official documentation](https://kubernetes.io/docs/home/) to setup a cluster.
+
+Use below command to start a lightweight Kubernetes cluster using k3s.
+
+```
+$ curl -sfL https://get.k3s.io | sh -
+```
+
+Check node status with below command. You can see current node status is ready.
+
+```
+$ kubectl get node
+NAME     STATUS   ROLES                  AGE   VERSION
+td-005   Ready    control-plane,master   4s    v1.29.4+k3s1
+```


### PR DESCRIPTION
The guide shows how to create GCP TD and install kubernetes cluster in the single node